### PR TITLE
changing buffer size to 50

### DIFF
--- a/cwl/vep_annotate.TinDaisy.cwl
+++ b/cwl/vep_annotate.TinDaisy.cwl
@@ -67,7 +67,7 @@ arguments:
       --xref_refseq --sift b --tsl --canonical --total_length --allele_number
       --variant_class --biotype --appris --flag_pick_allele --check_existing
       --failed 1 --minimal --pick_order biotype,rank,canonical --af --max_af
-      --af_1kg --af_esp --af_gnomad --buffer_size 500  --fork 4 
+      --af_1kg --af_esp --af_gnomad --buffer_size 50  --fork 4 
   - position: 0
     prefix: '--custom_args'
     valueFrom: >-

--- a/cwl/vep_annotate.TinDaisy.v100.cwl
+++ b/cwl/vep_annotate.TinDaisy.v100.cwl
@@ -54,7 +54,7 @@ arguments:
       --xref_refseq --sift b --tsl --canonical --total_length --allele_number
       --variant_class --biotype --appris --flag_pick_allele --check_existing
       --failed 1 --minimal --pick_order biotype,rank,canonical --af --max_af
-      --af_1kg --af_esp --af_gnomad --buffer_size 500  --fork 4 
+      --af_1kg --af_esp --af_gnomad --buffer_size 50  --fork 4 
   - position: 0
     prefix: '--custom_args'
     valueFrom: >-

--- a/cwl/vep_annotate.TinDaisy.v102.cwl
+++ b/cwl/vep_annotate.TinDaisy.v102.cwl
@@ -54,7 +54,7 @@ arguments:
       --xref_refseq --sift b --tsl --canonical --total_length --allele_number
       --variant_class --biotype --appris --flag_pick_allele --check_existing
       --failed 1 --minimal --pick_order biotype,rank,canonical --af --max_af
-      --af_1kg --af_esp --af_gnomad --buffer_size 500  --fork 4 
+      --af_1kg --af_esp --af_gnomad --buffer_size 50  --fork 4 
   - position: 0
     prefix: '--custom_args'
     valueFrom: >-

--- a/cwl/vep_annotate.TinDaisy.v99.cwl
+++ b/cwl/vep_annotate.TinDaisy.v99.cwl
@@ -54,7 +54,7 @@ arguments:
       --xref_refseq --sift b --tsl --canonical --total_length --allele_number
       --variant_class --biotype --appris --flag_pick_allele --check_existing
       --failed 1 --minimal --pick_order biotype,rank,canonical --af --max_af
-      --af_1kg --af_esp --af_gnomad --buffer_size 500  --fork 4 
+      --af_1kg --af_esp --af_gnomad --buffer_size 50  --fork 4 
   - position: 0
     prefix: '--custom_args'
     valueFrom: >-

--- a/cwl/vep_annotate.TinJasmine.cwl
+++ b/cwl/vep_annotate.TinJasmine.cwl
@@ -80,7 +80,7 @@ arguments:
 # --buffer_size 10000  --fork 4
 
 # Value for TinJasmine
-    valueFrom: '--buffer_size 500  --fork 4 --failed 0 --everything --af_exac'
+    valueFrom: '--buffer_size 50  --fork 4 --failed 0 --everything --af_exac'
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement

--- a/cwl/vep_annotate.TinJasmine.v100.cwl
+++ b/cwl/vep_annotate.TinJasmine.v100.cwl
@@ -57,7 +57,7 @@ arguments:
     valueFrom: results
   - position: 0
     prefix: '--vep_opts'
-    valueFrom: '--buffer_size 500  --fork 4 --failed 0 --everything --af_exac'
+    valueFrom: '--buffer_size 50  --fork 4 --failed 0 --everything --af_exac'
   - position: 0
     prefix: '--vep_cache_version'
     valueFrom: '100'

--- a/cwl/vep_annotate.TinJasmine.v102.cwl
+++ b/cwl/vep_annotate.TinJasmine.v102.cwl
@@ -57,7 +57,7 @@ arguments:
     valueFrom: results
   - position: 0
     prefix: '--vep_opts'
-    valueFrom: '--buffer_size 500  --fork 4 --failed 0 --everything --af_exac'
+    valueFrom: '--buffer_size 50  --fork 4 --failed 0 --everything --af_exac'
   - position: 0
     prefix: '--vep_cache_version'
     valueFrom: '102'

--- a/cwl/vep_annotate.TinJasmine.v99.cwl
+++ b/cwl/vep_annotate.TinJasmine.v99.cwl
@@ -57,7 +57,7 @@ arguments:
     valueFrom: results
   - position: 0
     prefix: '--vep_opts'
-    valueFrom: '--buffer_size 500  --fork 4 --failed 0 --everything --af_exac'
+    valueFrom: '--buffer_size 50  --fork 4 --failed 0 --everything --af_exac'
   - position: 0
     prefix: '--vep_cache_version'
     valueFrom: '99'


### PR DESCRIPTION
Buffer size of 500 was causing the following error:

ERROR: Forked process(es) died: read-through of cross-process communication detected

Reducing --buffer-size to 50 fixes the error.